### PR TITLE
Pull username and icon from webhook settings, correct crying cat emoji

### DIFF
--- a/octoprint_slack/__init__.py
+++ b/octoprint_slack/__init__.py
@@ -15,15 +15,45 @@ class SlackPlugin(octoprint.plugin.SettingsPlugin,
     def get_settings_defaults(self):
         return dict(
                 webhook_url="",
-                events=dict(
-                    PrintStarted=True,
-                    PrintFailed=True,
-                    PrintCancelled=True,
-                    PrintDone=True,
-                    PrintPaused=False,
-                    PrintResumed=False,
+                print_events=dict(
+                    PrintStarted=dict(
+                        Enabled=True,
+                        Message="A new print has started! :muscle:",
+                        Fallback="Print started! Filename: {}",
+                        Color="good",
+                        ),
+                    PrintFailed=dict(
+                        Enabled=True,
+                        Message="Oh no! The print has failed... :rage2:",
+                        Fallback="Print failed! Filename: {}",
+                        Color="danger",
+                        ),
+                    PrintCancelled=dict(
+                        Enabled=True,
+                        Message="Uh oh... someone cancelled the print! :crying_cat_face:",
+                        Fallback="Print cancelled! Filename: {}",
+                        Color="danger",
+                        ),
+                    PrintDone=dict(
+                        Enabled=True,
+                        Message="Print finished successfully! Filename: {}, Time: {}",
+                        Fallback="Print started! Filename: {}",
+                        Color="good",
+                        ),
+                    PrintPaused=dict(
+                        Enabled=True,
+                        Message="Printing has been paused... :sleeping:",
+                        Fallback="Print paused... Filename: {}",
+                        Color="warning",
+                        ),
+                    PrintResumed=dict(
+                        Enabled=True,
+                        Message="Phew! Printing has been resumed! Back to work... :hammer:",
+                        Fallback="Print resumed! Filename: {}",
+                        Color="good",
+                        ),
+                    ),
                 )
-            )
 
     def get_settings_version(self):
         return 1
@@ -36,89 +66,82 @@ class SlackPlugin(octoprint.plugin.SettingsPlugin,
     ## EventPlugin
 
     def on_event(self, event, payload):
-        enabled_events = self._settings.get(['events'])
-        if event in enabled_events and enabled_events[event]:
-            pass
+        events = self._settings.get(['print_events'])
+
+        if event in events and events[event] and events[event]['Enabled']:
+
+            webhook_url = self._settings.get(['webhook_url'])
+            if not webhook_url:
+                self._logger.exception("Slack Webhook URL not set!")
+                return
+
+            filename = os.path.basename(payload["file"])
+            if payload['origin'] == 'local':
+                origin = "Local"
+            elif payload['origin'] == 'sdcard':
+                origin = "SD Card"
+            else:
+                origin = payload['origin']
+
+            message = {}
+
+            ## bot display settings
+
+            ## if no username is set, it will default to the webhook username
+            username = self._settings.get(['bot_username'])
+            if username:
+                message['username'] = username
+
+            ## if an icon is set, use that. if not, use the emoji.
+            ## if neither are set, it will default to the webhook icon/emoji
+            icon_url = self._settings.get(['bot_icon_url'])
+            icon_emoji = self._settings.get(['bot_icon_emoji'])
+            if icon_url:
+                message['icon_url'] = icon_url
+            elif icon_emoji:
+                message['icon_emoji'] = icon_emoji
+
+            ## message settings
+            message['attachments'] = [{}]
+            attachment = message['attachments'][0]
+            attachment['fields'] = []
+            attachment['fields'].append( { "title": "Filename", "value": filename, "short": True } )
+            attachment['fields'].append( { "title": "Origin", "value": origin, "short": True } )
+
+            ## event settings
+            event_item = events.get(event)
+            event_default = self.get_settings_defaults().get('print_events').get(event)
+            ## if no value is set, use the default settings
+            event_merged = event_default
+            event_merged.update({k:v for k,v in event_item.iteritems() if v})
+
+            import datetime
+            import octoprint.util
+            if "time" in payload and payload["time"]:
+                elapsed_time = octoprint.util.get_formatted_timedelta(datetime.timedelta(seconds=payload["time"]))
+            else:
+                elapsed_time = ""
+
+            attachment['fallback'] = event_merged['Fallback'].format(filename, elapsed_time)
+            attachment['pretext'] = event_merged['Message']
+            attachment['color'] = event_merged['Color']
+
+            self._logger.debug("Attempting post of Slack message: {}".format(message))
+            try:
+                res = requests.post(webhook_url, data=json.dumps(message))
+            except Exception, e:
+                self._logger.exception("An error occurred connecting to Slack:\n {}".format(e.message))
+                return
+
+            if not res.ok:
+                self._logger.exception("An error occurred posting to Slack:\n {}".format(res.text))
+                return
+
+            self._logger.debug("Posted event successfully to Slack!")
+
         else:
             self._logger.debug("Slack not configured for event.")
             return
-
-        webhook_url = self._settings.get(['webhook_url'])
-        if webhook_url == "":
-            self._logger.exception("Slack Webhook URL not set!")
-            return
-
-        filename = os.path.basename(payload["file"])
-        if payload['origin'] == 'local':
-            origin = "Local"
-        elif payload['origin'] == 'sdcard':
-            origin = "SD Card"
-        else:
-            origin = payload['origin']
-
-        username = self._settings.get(['username'])
-        if username == "":
-            self._logger.exception("Webhook Username not set!")
-            return
-
-        icon = self._settings.get(['icon'])
-        if icon == "":
-            self._logger.exception("Webhook Icon not set!")
-            return
-
-        message = {}
-        message['username'] = username
-        message['icon_url'] = icon
-        message['attachments'] = [{}]
-        attachment = message['attachments'][0]
-        attachment['fields'] = []
-        attachment['fields'].append( { "title": "Filename", "value": filename, "short": True } )
-        attachment['fields'].append( { "title": "Origin", "value": origin, "short": True } )
-
-        if event == "PrintStarted":
-            attachment['fallback'] = "Print started! Filename: {}".format(filename)
-            attachment['pretext'] = "A new print has started! :muscle:"
-            attachment['color'] = "good"
-        elif event == "PrintFailed":
-            attachment['fallback'] = "Print failed! Filename: {}".format(filename)
-            attachment['pretext'] = "Oh no! The print has failed... :rage2:"
-            attachment['color'] = "danger"
-        elif event == "PrintDone":
-            import datetime
-            import octoprint.util
-            elapsed_time = octoprint.util.get_formatted_timedelta(datetime.timedelta(seconds=payload["time"]))
-
-            attachment['fallback'] = "Print finished successfully! Filename: {}, Time: {}".format(filename, elapsed_time)
-            attachment['pretext'] = "The print has finished successfully! :thumbsup:"
-            attachment['color'] = "good"
-            attachment['fields'].append( { "title": "Time", "value": elapsed_time, "short": True } )
-        elif event == "PrintCancelled":
-            attachment['fallback'] = "Print cancelled! Filename: {}".format(filename)
-            attachment['pretext'] = "Uh oh... someone cancelled the print! :crying_cat_face:"
-            attachment['color'] = "danger"
-        elif event == "PrintPaused":
-            attachment['fallback'] = "Print paused... Filename: {}".format(filename)
-            attachment['pretext'] = "Printing has been paused... :sleeping:"
-            attachment['color'] = "warning"
-        elif event == "PrintResumed":
-            attachment['fallback'] = "Print resumed! Filename: {}".format(filename)
-            attachment['pretext'] = "Phew! Printing has been resumed! Back to work... :hammer:"
-            attachment['color'] = "good"
-        else:
-            return
-
-        self._logger.debug("Attempting post of Slack message: {}".format(message))
-        try:
-            res = requests.post(webhook_url, data=json.dumps(message))
-        except Exception, e:
-            self._logger.exception("An error occurred connecting to Slack:\n {}".format(e.message))
-            return
-
-        if not res.ok:
-            self._logger.exception("An error occurred posting to Slack:\n {}".format(res.text))
-            return
-
-        self._logger.debug("Posted event successfully to Slack!")
 
 __plugin_name__ = "Slack"
 __plugin_implementation__ = SlackPlugin()

--- a/octoprint_slack/__init__.py
+++ b/octoprint_slack/__init__.py
@@ -56,9 +56,19 @@ class SlackPlugin(octoprint.plugin.SettingsPlugin,
         else:
             origin = payload['origin']
 
+        username = self._settings.get(['username'])
+        if username == "":
+            self._logger.exception("Webhook Username not set!")
+            return
+
+        icon = self._settings.get(['icon'])
+        if icon == "":
+            self._logger.exception("Webhook Icon not set!")
+            return
+
         message = {}
-        message['username'] = "OctoPrint"
-        message['icon_url'] = "http://octoprint.org/assets/img/logo.png"
+        message['username'] = username
+        message['icon_url'] = icon
         message['attachments'] = [{}]
         attachment = message['attachments'][0]
         attachment['fields'] = []
@@ -84,7 +94,7 @@ class SlackPlugin(octoprint.plugin.SettingsPlugin,
             attachment['fields'].append( { "title": "Time", "value": elapsed_time, "short": True } )
         elif event == "PrintCancelled":
             attachment['fallback'] = "Print cancelled! Filename: {}".format(filename)
-            attachment['pretext'] = "Uh oh... someone cancelled the print! :cryingcat:"
+            attachment['pretext'] = "Uh oh... someone cancelled the print! :crying_cat_face:"
             attachment['color'] = "danger"
         elif event == "PrintPaused":
             attachment['fallback'] = "Print paused... Filename: {}".format(filename)

--- a/octoprint_slack/templates/slack_settings.jinja2
+++ b/octoprint_slack/templates/slack_settings.jinja2
@@ -1,4 +1,4 @@
-<h3>{{ _('Slack Webhook Configuration') }}</h3>
+<h3>{{ _('Slack Plugin Configuration') }}</h3>
 
 <form class="form-horizontal">
 
@@ -9,55 +9,120 @@
         </div>
     </div>
 
+    <div class="control-group" title="{{ _('Username') }}">
+        <h4>Bot Configuration</h4>
+        <p>These settings change how your bot interacts with Slack. Leave blank to use the username/icon defined in your Webhook.</p>
+        <label class="control-label">{{ _('Username') }}</label>
+        <div class="controls">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.bot_username">
+        </div>
+    </div>
+
+    <div class="control-group" title="{{ _('Icon') }}">
+        <label class="control-label">{{ _('Icon URL') }}</label>
+        <div class="controls">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.bot_icon_url">
+        </div>
+    </div>
+
+    <div class="control-group" title="{{ _('Emoji') }}">
+        <label class="control-label">{{ _('Icon Emoji') }}</label>
+        <div class="controls">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.bot_icon_emoji">
+        </div>
+    </div>
+
     <h4>{{ _('Event Notifications') }}</h4>
 
-    <p>{{ _('Choose the events that send a message to Slack.') }}</p>
+    <p>{{ _('Choose the events that send a message to Slack. You can also customize the message itself (or leave blank to use the default).') }}</p>
 
     <div class="control-group">
+        <h5>Print Started</h5>
+        <label class="control-label">Message: </label>
         <div class="controls" title="{{ _('A print has started.') }}">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.slack.events.PrintStarted" /> {{ _('PrintStarted') }}
-            </label>
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.print_events.PrintStarted.Message">
         </div>
     </div>
 
     <div class="control-group">
-        <div class="controls" title="{{ _('A print failed.') }}">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.slack.events.PrintFailed" /> {{ _('PrintFailed') }}
-            </label>
+        <label class="control-label">Enabled: </label>
+        <div class="controls" title="{{ _('A print has started.') }}">
+            <input type="checkbox" data-bind="checked: settings.plugins.slack.print_events.PrintStarted.Enabled" />
         </div>
     </div>
 
     <div class="control-group">
-        <div class="controls" title="{{ _('A print completed successfully.') }}">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.slack.events.PrintDone" /> {{ _('PrintDone') }}
-            </label>
+        <h5>Print Failed</h5>
+        <label class="control-label">Message: </label>
+        <div class="controls" title="{{ _('A print has failed.') }}">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.print_events.PrintFailed.Message">
         </div>
     </div>
 
     <div class="control-group">
-        <div class="controls" title="{{ _('The print has been cancelled via the cancel button.') }}">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.slack.events.PrintCancelled" /> {{ _('PrintCancelled') }}
-            </label>
+        <label class="control-label">Enabled: </label>
+        <div class="controls" title="{{ _('A print has failed.') }}">
+            <input type="checkbox" data-bind="checked: settings.plugins.slack.print_events.PrintFailed.Enabled" />
         </div>
     </div>
 
     <div class="control-group">
-        <div class="controls" title="{{ _('The print has been paused.') }}">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.slack.events.PrintPaused" /> {{ _('PrintPaused') }}
-            </label>
+        <h5>Print Cancelled</h5>
+        <label class="control-label">Message: </label>
+        <div class="controls" title="{{ _('A print has been cancelled.') }}">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.print_events.PrintCancelled.Message">
         </div>
     </div>
 
     <div class="control-group">
-        <div class="controls" title="{{ _('The print has been resumed.') }}">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.slack.events.PrintResumed" /> {{ _('PrintResumed') }}
-            </label>
+        <label class="control-label">Enabled: </label>
+        <div class="controls" title="{{ _('A print has been cancelled.') }}">
+            <input type="checkbox" data-bind="checked: settings.plugins.slack.print_events.PrintCancelled.Enabled" />
+        </div>
+    </div>
+
+    <div class="control-group">
+        <h5>Print Done</h5>
+        <label class="control-label">Message: </label>
+        <div class="controls" title="{{ _('A print is done.') }}">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.print_events.PrintDone.Message">
+        </div>
+    </div>
+
+    <div class="control-group">
+        <label class="control-label">Enabled: </label>
+        <div class="controls" title="{{ _('A print is done.') }}">
+            <input type="checkbox" data-bind="checked: settings.plugins.slack.print_events.PrintDone.Enabled" />
+        </div>
+    </div>
+
+    <div class="control-group">
+        <h5>Print Paused</h5>
+        <label class="control-label">Message: </label>
+        <div class="controls" title="{{ _('A print has paused.') }}">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.print_events.PrintPaused.Message">
+        </div>
+    </div>
+
+    <div class="control-group">
+        <label class="control-label">Enabled: </label>
+        <div class="controls" title="{{ _('A print has paused.') }}">
+            <input type="checkbox" data-bind="checked: settings.plugins.slack.print_events.PrintPaused.Enabled" />
+        </div>
+    </div>
+
+    <div class="control-group">
+        <h5>Print Resumed</h5>
+        <label class="control-label">Message: </label>
+        <div class="controls" title="{{ _('A print has resumed.') }}">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.slack.print_events.PrintResumed.Message">
+        </div>
+    </div>
+
+    <div class="control-group">
+        <label class="control-label">Enabled: </label>
+        <div class="controls" title="{{ _('A print has resumed.') }}">
+            <input type="checkbox" data-bind="checked: settings.plugins.slack.print_events.PrintResumed.Enabled" />
         </div>
     </div>
 


### PR DESCRIPTION
Hi there!

I made small to change to have the OctoPrint Slack plugin use the username and icon you've configured for the webhook, rather than be hardcoded to the OctoPrint name and logo. That way, you can customize the name and icon easily.

Here's an example of how it looks: [doge-bot](http://i.imgur.com/w1IFvDc.png)

Also, I changed the reference to the crying cat emoji from :cryingcat: to :crying_cat_face:, which I believe is the correct name.

Thanks for making this amazing plugin!
