### PR TITLE
Restrict webhook setting to admins on API

### DIFF
--- a/octoprint_slack/__init__.py
+++ b/octoprint_slack/__init__.py
@@ -55,6 +55,21 @@ class SlackPlugin(octoprint.plugin.SettingsPlugin,
                     ),
                 )
 
+    def on_settings_load(self):
+        data = octoprint.plugin.SettingsPlugin.on_settings_load(self)
+
+        # only return our restricted settings to admin users - this is only needed for OctoPrint <= 1.2.16
+        restricted = ("webhook_url",)
+        for r in restricted:
+            if r in data and (current_user is None or current_user.is_anonymous() or not current_user.is_admin()):
+                data[r] = None
+
+        return data
+
+    def get_settings_restricted_paths(self):
+        # only used in OctoPrint versions > 1.2.16
+        return dict(admin=[["webhook_url"],])
+
     def get_settings_version(self):
         return 3
 

--- a/octoprint_slack/__init__.py
+++ b/octoprint_slack/__init__.py
@@ -6,6 +6,8 @@ import os
 import json
 import requests
 
+from flask.ext.login import current_user
+
 class SlackPlugin(octoprint.plugin.SettingsPlugin,
                   octoprint.plugin.TemplatePlugin,
                   octoprint.plugin.EventHandlerPlugin):


### PR DESCRIPTION
I recently noticed that I'd not properly protected some sensitive data in one of my own plugins. An API key was available on the settings API for basically everyone with access to the instance in question (settings API GET requests are not restricted since a lot of settings data is directly needed in the frontend for various things). Not a good idea. So I fixed that in my own plugin, added a new utility method in OctoPrint itself in future versions to allow to define restricted settings paths (already part of 1.2.17rc1) and thought I'd also go around and send some PRs to the plugins I know of that also might have sensitive data such as API keys and what not stored in their settings.

This PR is the result of that. I have to admit that I could not properly test it myself due to not having a Slack account, so please give it a test whirl before merging and releasing it.

The basic idea is to set sensitive settings fields to "None" if the settings load call does not originate from a user with admin rights.

Two implementations are provided, one for OctoPrint versions up to and including 1.2.16, and one for OctoPrint versions after 1.2.16 which come with a new method on the SettingsPlugin API to allow defining restricted paths.
